### PR TITLE
Add material form for material management

### DIFF
--- a/web/templates/material_form.html
+++ b/web/templates/material_form.html
@@ -1,0 +1,9 @@
+<form method="POST">
+  <label>Material Title</label>
+  <input type="text" name="title" placeholder="Enter material title" required>
+
+  <label>Description</label>
+  <textarea name="description" placeholder="Enter material description" required></textarea>
+
+  <button type="submit">Save Material</button>
+</form>

--- a/web/templates/material_form.html
+++ b/web/templates/material_form.html
@@ -1,9 +1,25 @@
-<form method="POST">
+<form method="POST" enctype="multipart/form-data">
   <label>Material Title</label>
   <input type="text" name="title" placeholder="Enter material title" required>
 
   <label>Description</label>
-  <textarea name="description" placeholder="Enter material description" required></textarea>
+  <textarea name="description" placeholder="Enter material description"></textarea>
+
+  <label>Media Type</label>
+  <select name="media_type">
+    <option value="text">Text</option>
+    <option value="pdf">PDF</option>
+    <option value="video">Video</option>
+    <option value="mixed">Mixed</option>
+  </select>
+
+  <label>Display Order</label>
+  <input type="number" name="display_order" value="0">
+
+  <label>
+    <input type="checkbox" name="is_published">
+    Publish material
+  </label>
 
   <button type="submit">Save Material</button>
 </form>


### PR DESCRIPTION
This PR adds a basic material form to support the material management feature.

- Created a simple form for adding material details (title, description, media type, publish status)
- Ensured compatibility with existing backend structure
- Kept implementation minimal to avoid conflicts with frontend layout work

This contributes to the material management functionality and will support further feature development.