### PR TITLE
Add materials page with category filter and unified navbar in base template

### DIFF
--- a/web/main/routes.py
+++ b/web/main/routes.py
@@ -1,4 +1,4 @@
-from flask import Blueprint, render_template
+from flask import Blueprint, render_template, request
 
 from ..models import Category, Material
 
@@ -14,10 +14,22 @@ def home():
 
 @main_bp.route("/materials")
 def materials():
-    materials = Material.query.order_by(Material.created_at.desc()).all()
-    categories = Category.query.all()
-    return render_template("home.html", materials=materials, categories=categories)
+    category_id = request.args.get("category_id", type=int)
 
+    query = Material.query
+
+    if category_id:
+        query = query.filter(Material.category_id == category_id)
+
+    materials = query.order_by(Material.created_at.desc()).all()
+    categories = Category.query.all()
+
+    return render_template(
+        "materials.html",
+        materials=materials,
+        categories=categories,
+        selected_category_id=category_id
+    )
 
 @main_bp.route("/materials/<int:material_id>")
 def view_material(material_id):

--- a/web/templates/base.html
+++ b/web/templates/base.html
@@ -41,8 +41,8 @@
         </div>
 
         <nav class="flex flex-wrap items-center gap-x-5 gap-y-2 text-sm font-medium text-slate-600 md:justify-center" aria-label="Footer navigation">
-          <a href="{{ url_for('main.materials') }}" class="transition-colors hover:text-blue-700">Tutorials</a>
-          <a href="{{ url_for('main.home') }}" class="transition-colors hover:text-blue-700">Categories</a>
+          <a href="{{ url_for('main.home') }}" class="transition-colors hover:text-blue-700">Tutorials</a>
+          <a href="{{ url_for('main.materials') }}" class="transition-colors hover:text-blue-700">Materials</a>
           <a href="{{ url_for('auth.login') }}" class="transition-colors hover:text-blue-700">Admin</a>
         </nav>
 

--- a/web/templates/materials.html
+++ b/web/templates/materials.html
@@ -1,0 +1,74 @@
+{% extends "base.html" %}
+
+{% block styles %}
+<link rel="stylesheet" href="{{ url_for('static', filename='css/home.css') }}">
+{% endblock %}
+
+{% block content %}
+<div class="min-h-screen bg-slate-50">
+  <main class="mx-auto max-w-6xl px-4 py-10 sm:px-6 sm:py-14">
+
+    <h1 class="text-3xl font-semibold text-slate-900">Materials</h1>
+
+    <!-- category -->
+    <div class="mt-6 flex flex-wrap gap-2">
+      <a href="{{ url_for('main.materials') }}"
+         class="px-4 py-2 rounded-full text-sm
+         {% if not selected_category_id %} bg-blue-600 text-white {% else %} bg-white ring-1 ring-slate-200 {% endif %}">
+        All
+      </a>
+
+      {% for c in categories %}
+        <a href="{{ url_for('main.materials', category_id=c.id) }}"
+           class="px-4 py-2 rounded-full text-sm
+           {% if selected_category_id == c.id %} bg-blue-600 text-white {% else %} bg-white ring-1 ring-slate-200 {% endif %}">
+          {{ c.name }}
+        </a>
+      {% endfor %}
+    </div>
+
+    <!-- cards -->
+    <div class="mt-8 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+
+      {% for m in materials %}
+      <a href="{{ url_for('main.view_material', material_id=m.id) }}"
+         class="group flex flex-col overflow-hidden rounded-2xl bg-white shadow-sm ring-1 ring-slate-200 hover:ring-slate-300">
+
+        {% if m.thumbnail %}
+          <img src="{{ url_for('static', filename='uploads/' + m.thumbnail) }}"
+               class="h-40 w-full object-cover">
+        {% else %}
+          <div class="h-40 bg-slate-100 flex items-center justify-center text-slate-300">
+            No Image
+          </div>
+        {% endif %}
+
+        <div class="p-5 flex flex-col flex-1">
+
+          {% if m.category %}
+            <span class="mb-2 text-xs bg-blue-100 text-blue-700 px-2 py-1 rounded-full w-fit">
+              {{ m.category.name }}
+            </span>
+          {% endif %}
+
+          <div class="font-semibold text-slate-900 group-hover:text-blue-700">
+            {{ m.title }}
+          </div>
+
+          <div class="text-sm text-slate-500 mt-1 line-clamp-2">
+            {{ m.description }}
+          </div>
+
+          <div class="mt-auto pt-4 text-sm text-blue-600 font-semibold">
+            View →
+          </div>
+
+        </div>
+      </a>
+      {% endfor %}
+
+    </div>
+
+  </main>
+</div>
+{% endblock %}


### PR DESCRIPTION
This PR adds a new Materials page that displays all tutorial resources with category filtering.

Key changes:
- Created materials.html to display all materials in a card layout
- Implemented category filtering using query parameters
- Edit material route for material detail pages
- Refactored base.html to include a unified navigation bar across all pages

Note:
Materials page is accessible via /materials