### PR TITLE
UI/UX enhance: responsive header & TEXT meterial view styling

### DIFF
--- a/web/templates/base.html
+++ b/web/templates/base.html
@@ -11,11 +11,13 @@
     <link href="https://unpkg.com/aos@2.3.1/dist/aos.css" rel="stylesheet">
     <script src="https://unpkg.com/aos@2.3.1/dist/aos.js"></script>
 
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/home.css') }}">
+
     {% block styles %}{% endblock %}
   </head>
 
   <body class="font-sans min-h-screen bg-slate-50 text-slate-900 antialiased flex flex-col">
-    <header class="border-b border-slate-200/70 bg-white/80 backdrop-blur">
+    <!-- <header class="border-b border-slate-200/70 bg-white/80 backdrop-blur">
       <div class="mx-auto flex max-w-6xl items-center justify-between px-4 py-4 sm:px-6">
         <a href="{{ url_for('main.home') }}" class="flex items-center gap-3">
           <span class="flex h-9 w-9 items-center justify-center rounded-lg bg-blue-600 text-white shadow-sm">
@@ -30,6 +32,38 @@
           <a href="{{ url_for('main.home') }}" class="nav-link">Home</a>
           <a href="{{ url_for('main.materials') }}" class="nav-link">Materials</a>
           <a href="{{ url_for('auth.login') }}" class="nav-link">Admin</a>
+        </nav>
+      </div>
+    </header> -->
+    <header class="border-b border-slate-200/70 bg-white/80 backdrop-blur sticky top-0 z-50">
+      <div class="mx-auto flex max-w-6xl items-center justify-between px-4 py-4 sm:px-6">
+        <a href="{{ url_for('main.home') }}" class="flex items-center gap-3">
+          <span class="flex h-9 w-9 items-center justify-center rounded-lg bg-blue-600 text-white shadow-sm">
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5A7.5 7.5 0 003 6.5v12A7.5 7.5 0 017.5 17c1.746 0 3.332.477 4.5 1.253m0 0C13.168 17.477 14.754 17 16.5 17A7.5 7.5 0 0121 18.5v-12A7.5 7.5 0 0016.5 5c-1.746 0-3.332.477-4.5 1.253" />
+            </svg>
+          </span>
+          <span class="text-base font-semibold tracking-tight text-slate-900">WMAA Tutorials</span>
+        </a>
+    
+        <nav class="hidden items-center gap-1 sm:flex">
+          <a href="{{ url_for('main.home') }}" class="nav-link">Home</a>
+          <a href="{{ url_for('main.materials') }}" class="nav-link">Materials</a>
+          <a href="{{ url_for('auth.login') }}" class="nav-link">Admin</a>
+        </nav>
+    
+        <button id="mobile-menu-button" class="rounded-lg p-2 text-slate-600 hover:bg-slate-100 sm:hidden focus:outline-none">
+          <svg class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16m-7 6h7" />
+          </svg>
+        </button>
+      </div>
+    
+      <div id="mobile-menu" class="hidden border-t border-slate-100 bg-white sm:hidden">
+        <nav class="flex flex-col space-y-1 px-4 py-4">
+          <a href="{{ url_for('main.home') }}" class="block rounded-lg px-3 py-2 text-base font-medium text-slate-700 hover:bg-slate-50 hover:text-blue-600">Home</a>
+          <a href="{{ url_for('main.materials') }}" class="block rounded-lg px-3 py-2 text-base font-medium text-slate-700 hover:bg-slate-50 hover:text-blue-600">Materials</a>
+          <a href="{{ url_for('auth.login') }}" class="block rounded-lg px-3 py-2 text-base font-medium text-slate-700 hover:bg-slate-50 hover:text-blue-600">Admin</a>
         </nav>
       </div>
     </header>
@@ -76,6 +110,18 @@
       AOS.init({
         duration: 1000, // the animation lasts for 1 second
         once: true,     // the animation happen only once
+      });
+    </script>
+
+    <script>
+      document.addEventListener('DOMContentLoaded', () => {
+        const btn = document.getElementById('mobile-menu-button');
+        const menu = document.getElementById('mobile-menu');
+        if (btn && menu) {
+          btn.addEventListener('click', () => {
+            menu.classList.toggle('hidden');
+          });
+        }
       });
     </script>
   </body>

--- a/web/templates/view_material.html
+++ b/web/templates/view_material.html
@@ -51,8 +51,10 @@
 
   <!-- Rich text content -->
   {% if material.content and material.content != '<p><br></p>' %}
-    <div class="prose prose-slate mt-8 max-w-none">
-      {{ material.content | safe }}
+    <div class="mt-10 rounded-3xl bg-gradient-to-b from-white to-blue-50/60 p-10 shadow-sm border border-slate-100">
+      <div class="prose prose-slate prose-lg max-w-none">
+        {{ material.content | safe }}
+      </div>
     </div>
   {% endif %}
 


### PR DESCRIPTION
Hi, I did the below UI/UX enhancment and fixes, plz review.

- Responsive Header: Added a mobile hamburger menu (resolves #31 ) and made the header sticky for easier navigation during scrolling.
- TEXT-type View Styling: Polished the tutorial content area with a subtle light blue background and improved typography to match WMAA branding.
- Bug Fixes: Resolved #35 (navigation hover effects only working on Home) and #32 (header missing on certain pages) by adjusting navigation styles at the global base template.

If the sticky style of header is intrusive, I can revert it to a standard scroll.

<img width="300" alt="Mobile menu" src="https://github.com/user-attachments/assets/fd3cb09e-9362-4c07-94bf-018aaf9ff04b" />

<img width="600" alt="Text materials view styling" src="https://github.com/user-attachments/assets/f3909f1a-d8da-4040-a2f6-ad6ffc3e75fd" />

<img width="600" alt="Header hover fix" src="https://github.com/user-attachments/assets/3c4e15e4-0982-4293-a5af-8d072a16b8b5" />